### PR TITLE
fix(picture-size): fix optimal picture size in perfect match

### DIFF
--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -436,6 +436,8 @@ public class CameraActivity extends Fragment {
       size.height = temp;
     }
 
+    Camera.Size requestedSize = mCamera.new Size(size.width, size.height);
+
     double previewAspectRatio  = (double)previewSize.width / (double)previewSize.height;
 
     if (previewAspectRatio < 1.0) {
@@ -452,7 +454,7 @@ public class CameraActivity extends Fragment {
       Camera.Size supportedSize = supportedSizes.get(i);
 
       // Perfect match
-      if (supportedSize.equals(size)) {
+      if (supportedSize.equals(requestedSize)) {
         Log.d(TAG, "CameraPreview optimalPictureSize " + supportedSize.width + 'x' + supportedSize.height);
         return supportedSize;
       }


### PR DESCRIPTION
Réplica de [este commit](https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/commit/dc0b1bef10bb5dba48b68f462047368b067d133e) para arreglar un error que se da en algunos dispositivos android. No considera el tamaño de foto que se le da, y toma fotos muy grandes, lo que trae varios problemas. 